### PR TITLE
Potential fix for code scanning alert no. 17: Uncontrolled command line

### DIFF
--- a/Season-2/Level-3/code.js
+++ b/Season-2/Level-3/code.js
@@ -77,10 +77,17 @@ app.post("/ufo", (req, res) => {
         xmlDoc.toString().includes('SYSTEM "') &&
         xmlDoc.toString().includes(".admin")
       ) {
+        const allowedCommands = ["ls", "pwd", "whoami"]; // Allowlist of permitted commands
         extractedContent.forEach((command) => {
+          if (!allowedCommands.includes(command)) {
+            console.error("Blocked unsafe command: ", command);
+            res.status(400).send("Invalid command.");
+            return;
+          }
           exec(command, (err, output) => {
             if (err) {
               console.error("could not execute command: ", err);
+              res.status(500).send("Command execution failed.");
               return;
             }
             console.log("Output: \n", output);


### PR DESCRIPTION
Potential fix for [https://github.com/AKA-NETWORK/vigilant-octo/security/code-scanning/17](https://github.com/AKA-NETWORK/vigilant-octo/security/code-scanning/17)

To fix this issue, we must ensure that user-provided input is not directly passed to `exec`. This can be done by:
1. Using `execFile` or `execFileSync` instead of `exec`, as these alternatives allow passing arguments as an array of strings, which avoids shell interpretation.
2. Validating or sanitizing the user-provided input to ensure it only contains safe commands or arguments.
3. Adding an allowlist of permitted commands and verifying that each user-provided command matches a predefined safe pattern.

In this case, the best fix is to validate each `command` against an allowlist of permitted commands. If the command is not in the allowlist, it should be discarded or cause an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
